### PR TITLE
修复日志过长导致服务异常的问题

### DIFF
--- a/src/Boot/Bootstrap.php
+++ b/src/Boot/Bootstrap.php
@@ -25,6 +25,7 @@ use YouzanCloudBoot\ExtensionPoint\BepRegistry;
 use YouzanCloudBoot\ExtensionPoint\MepRegistry;
 use YouzanCloudBoot\Http\HttpClientWrapper;
 use YouzanCloudBoot\Log\HostnameProcessor;
+use YouzanCloudBoot\Log\YouzanLogger;
 use YouzanCloudBoot\Log\YouzanSkynetProcessor;
 use YouzanCloudBoot\Store\PDOFactory;
 use YouzanCloudBoot\Store\RedisFactory;
@@ -53,7 +54,7 @@ class Bootstrap
             /** @var EnvUtil $envUtil */
             $envUtil = $container->get('envUtil');
             $applicationName = $envUtil->getAppName();
-            $logger = new Logger($applicationName);
+            $logger = new YouzanLogger($applicationName);
 
             //控制台输出
             $logger->pushHandler(new StreamHandler('php://stdout', Logger::INFO));

--- a/src/Boot/Bootstrap.php
+++ b/src/Boot/Bootstrap.php
@@ -75,6 +75,11 @@ class Bootstrap
                 $logger->pushHandler($socketHandler);
             }
 
+            // 异常捕获
+            $logger->setExceptionHandler(function (\Exception $e, array $record) {
+
+            });
+
             return $logger;
         };
         $container['bepRegistry'] = function (ContainerInterface $container) {

--- a/src/Facades/LogFacade.php
+++ b/src/Facades/LogFacade.php
@@ -26,6 +26,8 @@ namespace YouzanCloudBoot\Facades;
 class LogFacade extends Facade
 {
 
+    private const MAX_LENGTH = 10240;
+
     /**
      * 给静态代理设置服务名称
      * 子类必须覆盖这个方法
@@ -35,5 +37,16 @@ class LogFacade extends Facade
     protected static function getFacadeAccessor(): string
     {
         return 'logger';
+    }
+
+    public static function __callStatic($method, $arguments)
+    {
+        if (is_array($arguments) && isset($arguments[0])) {
+            if (strlen(json_encode($arguments)) > self::MAX_LENGTH) {
+                $arguments = [substr($arguments[0], 0, self::MAX_LENGTH)];
+            }
+        }
+
+        return static::self()->$method(...$arguments);
     }
 }

--- a/src/Facades/LogFacade.php
+++ b/src/Facades/LogFacade.php
@@ -26,8 +26,6 @@ namespace YouzanCloudBoot\Facades;
 class LogFacade extends Facade
 {
 
-    private const MAX_LENGTH = 10240;
-
     /**
      * 给静态代理设置服务名称
      * 子类必须覆盖这个方法
@@ -37,16 +35,5 @@ class LogFacade extends Facade
     protected static function getFacadeAccessor(): string
     {
         return 'logger';
-    }
-
-    public static function __callStatic($method, $arguments)
-    {
-        if (is_array($arguments) && isset($arguments[0])) {
-            if (strlen(json_encode($arguments)) > self::MAX_LENGTH) {
-                $arguments = [substr($arguments[0], 0, self::MAX_LENGTH)];
-            }
-        }
-
-        return static::self()->$method(...$arguments);
     }
 }

--- a/src/Log/YouzanLogger.php
+++ b/src/Log/YouzanLogger.php
@@ -15,10 +15,13 @@ class YouzanLogger extends Logger
     public function addRecord($level, $message, array $context = array())
     {
         if (is_string($message) && strlen($message) > self::MAX_LENGTH) {
-            $message = mb_substr($message, 0, self::MAX_LENGTH);
+            // 采用mb_substr按字符截断 可以解决一个中文字被截断的问题 但会可能会超出MAX_LENGTH
+            // 采用substr按字节截断 可以严格限制MAX_LENGTH 但可能导致中文字被截断
+            $message = substr($message, 0, self::MAX_LENGTH);
         }
 
         if (is_array($context) && count($context) > 0) {
+            // 如果附属array超出MAX_LENGTH 直接置为空
             if (strlen(json_encode($context)) > self::MAX_LENGTH) {
                 $context = array();
             }

--- a/src/Log/YouzanLogger.php
+++ b/src/Log/YouzanLogger.php
@@ -1,0 +1,30 @@
+<?php
+
+
+namespace YouzanCloudBoot\Log;
+
+
+use Monolog\Logger;
+
+class YouzanLogger extends Logger
+{
+
+    private const MAX_LENGTH = 10240;
+
+
+    public function addRecord($level, $message, array $context = array())
+    {
+        if (is_string($message) && strlen($message) > self::MAX_LENGTH) {
+            $message = mb_substr($message, 0, self::MAX_LENGTH);
+        }
+
+        if (is_array($context) && count($context) > 0) {
+            if (strlen(json_encode($context)) > self::MAX_LENGTH) {
+                $context = array();
+            }
+        }
+
+        parent::addRecord($level, $message, $context);
+    }
+
+}

--- a/src/Log/YouzanLogger.php
+++ b/src/Log/YouzanLogger.php
@@ -24,7 +24,7 @@ class YouzanLogger extends Logger
             }
         }
 
-        parent::addRecord($level, $message, $context);
+        return parent::addRecord($level, $message, $context);
     }
 
 }


### PR DESCRIPTION
1. 日志长度大于10KB的，进行截断；第二参数大于10KB的置空
2. 对写日志异常进行捕获